### PR TITLE
Fix link to actions marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ jobs:
 
 ### Installing with GitHub Marketplace
 
-https://github.com/marketplace/actions/scalafmt
+https://github.com/marketplace/actions/scalafmt-action
 
 ### (Legacy) HCL Syntax
 


### PR DESCRIPTION
Maybe this link isn't even needed, because GitHub advertises the marketplace with same link very prominently:

![Screen Shot 2019-12-20 at 13 17 58](https://user-images.githubusercontent.com/818446/71254421-29331180-232b-11ea-8b60-9b19cac0a05c.png)
.

