### PR TITLE
Switch to upstream scalameta/scalafmt-native

### DIFF
--- a/.github/testdata/.scalafmt.conf
+++ b/.github/testdata/.scalafmt.conf
@@ -1,3 +1,1 @@
-# I dont like this formatting directive in reality, but lets
-# us verify that this is reading a conf file easily
-align = most
+align.preset = most

--- a/.github/testdata/Good.scala
+++ b/.github/testdata/Good.scala
@@ -15,7 +15,6 @@ sealed abstract class Formatted {
 }
 
 /** Aligned by first asterisk, default ScalaDoc style is second.
-  *
   */
 object Formatted {
   case class Success(formattedCode: String) extends Formatted

--- a/.github/testdata/README.md
+++ b/.github/testdata/README.md
@@ -1,0 +1,4 @@
+# test data
+
+[`.scalafmt.conf`](.scalafmt.conf) is known to pass on [`Good.scala`](Good.scala) and fail on [`Bad.scala`](Bad.scala).
+These are used during CI to verify that `scalafmt` is actually being executed.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
   check-testdata:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Checking testdata
         uses: ./
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
-# This is essentially just scalafmt-native loaded into an alpine container, so
-# that we have a shell present to expand wildcards etc.
-FROM mrothy/scalafmt-native:2.3.2 as scalafmt-native
+FROM scalameta/scalafmt:v2.7.5 as scalafmt-native
 
 FROM alpine:latest
 LABEL "repository"="https://github.com/openlawteam/scalafmt-ci"
 LABEL "homepage"="https://github.com/openlawteam/scalafmt-ci"
 LABEL "maintainer"="Matthew Rothenberg <mroth@openlaw.io>"
 
-COPY --from=scalafmt-native /app/scalafmt /usr/local/bin/scalafmt
+COPY --from=scalafmt-native /bin/scalafmt /bin/scalafmt
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["--list"]

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test:
 		$(IMAGE) --list --exclude Bad.scala
 
 # expected failure, to see output
-testfail: 
+testfail:
 	docker run --rm -it \
 		-w=$(WORKDIR) \
 		-v "$$(pwd)/$(TESTDATA)":$(WORKDIR) \

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Runs `scalafmt --list` on your repository automatically with every push.
 
-Uses [scalafmt-native](https://github.com/mroth/scalafmt-native) under the hood
-to keep things small and booting super quick by avoiding the JVM. :racehorse:
+Uses [scalafmt-native](https://scalameta.org/scalafmt/docs/installation.html#native-image)
+under the hood to keep things small and booting super quick by avoiding the JVM. :racehorse:
 
 ## Usage
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-sh -c "/usr/local/bin/scalafmt --non-interactive $*"
+sh -c "/bin/scalafmt --non-interactive $*"


### PR DESCRIPTION
[`mroth/scalafmt-native`](https://github.com/mroth/scalafmt-native) has been deprecated in favor of [`scalameta/scalafmt`](https://github.com/scalameta/scalafmt) producing its own native Docker image.

This PR updates `scalafmt-ci` to use the upstream `scalameta/scalafmt` at its latest version (`2.7.5`).

cc @mroth 